### PR TITLE
Introduce Linux/Avahi mDNS compatibility, while retaining the original OSX specifics.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,9 +3,9 @@ TARGET=libairplay
 SRCDIR=src/
 OBJDIR=obj/
 
-CC=clang++
-CFLAGS=-c -std=c++17 -Iinclude/ -g -O2 -Wall -Wno-unused-function -Wshadow -fno-rtti -fblocks
-LDFLAGS=-stdlib=libc++ -lpthread -g
+CC?=clang++
+CFLAGS?=-c -std=c++17 -Iinclude/ -g -O2 -Wall -Wno-unused-function -Wshadow -fno-rtti -fblocks
+LDFLAGS?=-stdlib=libc++ -lpthread -g
 
 SRCS=$(wildcard $(SRCDIR)*.cpp)
 OBJS=$(addprefix $(OBJDIR),$(notdir $(SRCS:.cpp=.o)))
@@ -17,7 +17,7 @@ $(OBJDIR):
 	mkdir -p $(OBJDIR)
 
 $(TARGET): $(OBJS)
-	$(CC) $(LDFLAGS) $(OBJS) -o $(TARGET)
+	$(CC) $(LDFLAGS) $(OBJS) -o $(TARGET) $(LIBS)
 
 $(OBJDIR)%.o: $(SRCDIR)%.cpp
 	$(CC) $(CFLAGS) $< -o $@

--- a/Makefile.linux
+++ b/Makefile.linux
@@ -1,0 +1,6 @@
+# GNU make
+CFLAGS=-c -std=c++17 -Iinclude/ -g -O2 -Wall -Wno-unused-function -Wshadow -fno-rtti -DAVAHI_COMPAT=1
+LDFLAGS=-lpthread -g
+LIBS=-lstdc++ -ldns_sd
+
+include Makefile

--- a/Makefile.osx
+++ b/Makefile.osx
@@ -1,0 +1,6 @@
+# Which is technically BSD-derived Makefile(5)
+CC=clang++
+CFLAGS=-c -std=c++17 -Iinclude/ -g -O2 -Wall -Wno-unused-function -Wshadow -fno-rtti -fblocks
+LDFLAGS=-stdlib=libc++ -lpthread -g
+
+include Makefile

--- a/README.md
+++ b/README.md
@@ -7,5 +7,16 @@ A C++ library to stream photos and videos via Airplay.
 including but not limited to Apple TV's.
 - Straightforward options and actions (the [airplay-hangman](https://github.com/firebolt55439/airplay-hangman) repository uses this).
 
-Be advised that this project makes use of system calls only available on macOS, and
-will require some tweaking to make it compatible with Linux-based OS's.
+# Building
+
+## MacOS
+```sh
+# Use Xcode/BSD-derived make:
+make -f Makefile.osx
+```
+
+## Linux
+```sh
+# Needs Avahi/mDNS compatibility libraries installed. Use GNU make:
+$ make -f Makefile.linux
+```

--- a/include/safe_socket.hpp
+++ b/include/safe_socket.hpp
@@ -38,6 +38,11 @@ public:
     void connect(const address& remote_address);
     void send(const buffer& data);
     buffer recv(size_t bytes_to_read);
+#ifdef AVAHI_COMPAT
+    // This is here, just because there's no better place for it now.
+    // Needed to fix the AVAHI quircks, that requires a non-blocking socket.
+    static int set_nonblocking(int socket);
+#endif
 
 private:
     const auto_close_fd _fd;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -6,6 +6,9 @@
 #include "airplay_browser.hpp"
 
 __attribute__((weak)) int main() {
+#ifdef AVAHI_COMPAT
+    setenv("AVAHI_COMPAT_NOWARN", "y", 0); // disable the annoying warnign!
+#endif
     std::cout << "[+] Fetching AirPlay devices:" << std::endl;
     const auto devices = airplay_browser::get_devices();
     for (auto device : devices) {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -10,10 +10,12 @@ __attribute__((weak)) int main() {
     const auto devices = airplay_browser::get_devices();
     for (auto device : devices) {
         std::cout << "     > " << device.first << std::endl;
+        std::cout << "     > " << device.second.get_printable_address() << std::endl;
     }
 
     std::cout << "[+] Connecting to device:" << std::endl;
-    airplay_device appletv(devices.at("Living Room Apple TV"));
+    airplay_device appletv(devices.begin()->second);
+//    airplay_device appletv(devices.at("Samsung Q50 Series LR"));
     std::cout << appletv.send_message(MessageType::GetServices) << std::endl;
 
     return 0;


### PR DESCRIPTION
Introduce Avahi mDNS compatibility, honoring its quirks (the non-blocking socket), while retaining the original OSX specifics.

Slightly improve the demo (eliminate hardcoded device name).